### PR TITLE
Added Per-Page Instruction Description for RV32I

### DIFF
--- a/src/instrs/instr-encoding-rv_i.adoc
+++ b/src/instrs/instr-encoding-rv_i.adoc
@@ -1,0 +1,2192 @@
+=== Instructions
+
+[[instruction-add]]
+==== ADD
+
+Synopsis:: Add two values
+
+Mnemonic::
++
+`add rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Adds rs1 and rs2, writing the result to rd. This basic arithmetic operation is fundamental in almost all computational tasks. It's used in address calculations, loop counters, array indexing, and general arithmetic operations in high-level languages. In more complex mathematical operations, ADD forms the basis for multi-word arithmetic and can be used to implement higher-precision calculations. It's also used in pointer arithmetic and in implementing certain algorithms like checksums.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_ADD(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = rs1_val + rs2_val,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-addi]]
+==== ADDI
+
+Synopsis:: Add Immediate
+
+Mnemonic::
++
+`addi rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x13, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Adds the 12-bit sign-extended immediate to rs1 and writes the result to rd. This is one of the most frequently used instructions in RISC-V, serving multiple purposes. It's used for basic arithmetic with small constants, for adjusting pointers (e.g., accessing structure fields or array elements), and for loading small signed constants into registers. In RV64, it sign-extends the result to 64 bits. ADDI with a zero immediate is used to move values between registers. It's also key in implementing higher-level language constructs like local variable allocation on the stack.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_ADDI (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result = rs1_val + immext,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-and]]
+==== AND
+
+Synopsis:: AND two values
+
+Mnemonic::
++
+`and rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x7, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Performs bitwise AND between rs1 and rs2, writing the result to rd. This instruction is fundamental in bitwise operations and is extensively used in various low-level programming tasks. It's crucial for masking operations, where specific bits need to be isolated or cleared while leaving others unchanged. AND is commonly used in flag manipulation, for extracting specific bitfields from larger words, and in implementing logical operations in boolean algebra. In embedded systems, it's often used for clearing specific bits in control registers. AND is also key in certain optimization techniques where only specific bits of a value are significant, and in implementing bitwise algorithms in cryptography and hash functions.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_AND(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = rs1_val & rs2_val,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-andi]]
+==== ANDI
+
+Synopsis:: AND Immediate
+
+Mnemonic::
++
+`andi rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x13, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x7, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Performs bitwise AND between rs1 and the sign-extended 12-bit immediate, writing the result to rd. This instruction is crucial for masking operations, where specific bits need to be isolated or cleared. It's commonly used in bit manipulation, for example, to clear the upper bits of a value or to extract specific bitfields. ANDI is also key in implementing bitwise flags and in certain optimizations where only the lower bits of a value are significant. In boolean algebra, it's used for logical AND operations with constants.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_ANDI (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result = rs1_val & immext,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-auipc]]
+==== AUIPC
+
+Synopsis:: Add Upper Immediate to PC
+
+Mnemonic::
++
+`auipc rd, imm[31:12]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x17, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 20, name: 'imm[31:12]'}
+]}
+....
+
+Description:: Adds a 20-bit immediate value (shifted left by 12 bits) to the current PC (Program Counter), storing the full 32-bit result in the destination register. This instruction is particularly useful for PC-relative addressing, especially when used in conjunction with JALR for implementing large PC-relative offsets. It allows for efficient encoding of 32-bit PC-relative addresses, which is crucial for position-independent code. The immediate value is sign-extended and shifted left by 12 bits before being added to the PC, allowing for a range of ±2 GiB around the current PC.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|imm20 |input |20-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute RISCV_AUIPC(imm, rd, op) = {
+  let off : xlenbits = sign_extend(imm @ 0x000);
+  let ret = get_arch_pc() + off
+  X(rd) = ret;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-beq]]
+==== BEQ
+
+Synopsis:: Branch if Equal
+
+Mnemonic::
++
+`beq rs1, rs2, imm[12:1]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x63, attr: ["OP"]},
+{bits: 1, name: '[11]'},
+{bits: 4, name: 'imm[4:1]'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 6, name: 'imm[10:5]'},
+{bits: 1, name: '[12]'}
+]}
+....
+
+Description:: Compares two registers (rs1 and rs2) and conditionally branches if they are equal. If the condition is true, the program counter is updated to PC + immediate, where the immediate is a signed 13-bit offset counting in 2-byte units. This allows for branches within a ±4 KiB range. BEQ is fundamental for implementing conditional statements and loops in high-level languages. It's often used in combination with other branch instructions to create more complex conditions. The zero-overhead loop feature in some RISC-V implementations can use this instruction for loop termination checks.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|bimm12hi |input |High bits of 12-bit branch offset
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|bimm12lo |input |Low bits of 12-bit branch offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_BEQ(imm, rs2, rs1)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken = rs1_val == rs2_val,
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C)) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-bge]]
+==== BGE
+
+Synopsis:: Branch if Greater than or Equal (Signed)
+
+Mnemonic::
++
+`bge rs1, rs2, imm[12:1]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x63, attr: ["OP"]},
+{bits: 1, name: '[11]'},
+{bits: 4, name: 'imm[4:1]'},
+{bits: 3, name: 0x5, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 6, name: 'imm[10:5]'},
+{bits: 1, name: '[12]'}
+]}
+....
+
+Description:: Compares two registers (rs1 and rs2) as signed integers and conditionally branches if rs1 is greater than or equal to rs2. If the condition is true, the program counter is updated to PC + immediate, where the immediate is a signed 13-bit offset counting in 2-byte units. This instruction complements BLT and is used in similar contexts for signed integer comparisons. It's particularly useful in implementing the upper bound checks in loops and in range-checking operations. BGE can be used to implement less-than-or-equal comparisons by swapping the order of the operands.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|bimm12hi |input |High bits of 12-bit branch offset
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|bimm12lo |input |Low bits of 12-bit branch offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_BGE(imm, rs2, rs1)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken = rs1_val >=_s rs2_val,
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C)) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-bgeu]]
+==== BGEU
+
+Synopsis:: Branch if Greater than or Equal (Unsigned)
+
+Mnemonic::
++
+`bgeu rs1, rs2, imm[12:1]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x63, attr: ["OP"]},
+{bits: 1, name: '[11]'},
+{bits: 4, name: 'imm[4:1]'},
+{bits: 3, name: 0x7, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 6, name: 'imm[10:5]'},
+{bits: 1, name: '[12]'}
+]}
+....
+
+Description:: Compares two registers (rs1 and rs2) as unsigned integers and conditionally branches if rs1 is greater than or equal to rs2. If the condition is true, the program counter is updated to PC + immediate, where the immediate is a signed 13-bit offset counting in 2-byte units. This instruction complements BLTU and is used for similar unsigned comparison operations. It's particularly useful for implementing upper bound checks in loops with unsigned counters, and in range-checking operations involving memory addresses or other unsigned values. BGEU can be used to implement less-than-or-equal comparisons for unsigned integers by swapping the order of the operands.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|bimm12hi |input |High bits of 12-bit branch offset
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|bimm12lo |input |Low bits of 12-bit branch offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_BGEU(imm, rs2, rs1)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken = rs1_val >=_u rs2_val
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C)) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-blt]]
+==== BLT
+
+Synopsis:: Branch if Less Than (Signed)
+
+Mnemonic::
++
+`blt rs1, rs2, imm[12:1]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x63, attr: ["OP"]},
+{bits: 1, name: '[11]'},
+{bits: 4, name: 'imm[4:1]'},
+{bits: 3, name: 0x4, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 6, name: 'imm[10:5]'},
+{bits: 1, name: '[12]'}
+]}
+....
+
+Description:: Compares two registers (rs1 and rs2) as signed integers and conditionally branches if rs1 is less than rs2. If the condition is true, the program counter is updated to PC + immediate, where the immediate is a signed 13-bit offset counting in 2-byte units. This instruction is crucial for implementing signed comparisons in loops and conditional statements. It's often used in sorting algorithms, binary searches, and other comparison-based operations. BLT can be combined with BGE to create equality comparisons for signed integers.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|bimm12hi |input |High bits of 12-bit branch offset
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|bimm12lo |input |Low bits of 12-bit branch offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_BLT(imm, rs2, rs1)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken = rs1_val <_s rs2_val,
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C)) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-bltu]]
+==== BLTU
+
+Synopsis:: Branch if Less Than (Unsigned)
+
+Mnemonic::
++
+`bltu rs1, rs2, imm[12:1]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x63, attr: ["OP"]},
+{bits: 1, name: '[11]'},
+{bits: 4, name: 'imm[4:1]'},
+{bits: 3, name: 0x6, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 6, name: 'imm[10:5]'},
+{bits: 1, name: '[12]'}
+]}
+....
+
+Description:: Compares two registers (rs1 and rs2) as unsigned integers and conditionally branches if rs1 is less than rs2. If the condition is true, the program counter is updated to PC + immediate, where the immediate is a signed 13-bit offset counting in 2-byte units. BLTU is essential for unsigned comparisons, which are often used with memory addresses, array indices, and other naturally unsigned values. It's particularly useful in bounds checking for arrays and in implementing unsigned arithmetic operations. BLTU can be more efficient than BLT for certain types of comparisons, especially when dealing with memory addresses.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|bimm12hi |input |High bits of 12-bit branch offset
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|bimm12lo |input |Low bits of 12-bit branch offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_BLTU(imm, rs2, rs1)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken = rs1_val <_u rs2_val,
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C)) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-bne]]
+==== BNE
+
+Synopsis:: Branch if Not Equal
+
+Mnemonic::
++
+`bne rs1, rs2, imm[12:1]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x63, attr: ["OP"]},
+{bits: 1, name: '[11]'},
+{bits: 4, name: 'imm[4:1]'},
+{bits: 3, name: 0x1, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 6, name: 'imm[10:5]'},
+{bits: 1, name: '[12]'}
+]}
+....
+
+Description:: Compares two registers (rs1 and rs2) and conditionally branches if they are not equal. If the condition is true, the program counter is updated to PC + immediate, where the immediate is a signed 13-bit offset counting in 2-byte units. This allows for branches within a ±4 KiB range. BNE is widely used in implementing loops, especially for loop continuation conditions. It's also used in conditional statements and in implementing more complex control flow structures. In combination with BEQ, it forms the basis for most conditional branching in RISC-V assembly.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|bimm12hi |input |High bits of 12-bit branch offset
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|bimm12lo |input |Low bits of 12-bit branch offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_BNE(imm, rs2, rs1)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken = rs1_val != rs2_val,
+  let t : xlenbits = PC + sign_extend(imm);
+  if taken then {
+    /* Extensions get the first checks on the target address. */
+    match ext_control_check_pc(t) {
+      Ext_ControlAddr_Error(e) => {
+        ext_handle_control_check_error(e);
+        RETIRE_FAIL
+      },
+      Ext_ControlAddr_OK(target) => {
+        if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C)) then {
+          handle_mem_exception(target, E_Fetch_Addr_Align());
+          RETIRE_FAIL;
+        } else {
+          set_next_pc(target);
+          RETIRE_SUCCESS
+        }
+      }
+    }
+  } else RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-ebreak]]
+==== EBREAK
+
+Synopsis:: Environment break
+
+Mnemonic::
++
+`ebreak`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 32, name: 0x100073, attr: ["OP"]}
+]}
+....
+
+Description:: Triggers a breakpoint exception, transferring control to a debug environment. This instruction is primarily used for debugging purposes, allowing programmers to set breakpoints in their code for step-by-step execution and inspection. When an EBREAK is encountered during normal execution, it causes the processor to enter debug mode, where the program's state can be examined and modified. This is crucial for identifying and fixing bugs, especially in embedded systems or operating system development where traditional software debuggers might not be available. EBREAK is also sometimes used in implementing system calls or other privilege-level transitions in some RISC-V systems.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute EBREAK() = {
+  handle_mem_exception(PC, E_Breakpoint());
+  RETIRE_FAIL
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-ecall]]
+==== ECALL
+
+Synopsis:: Environment call
+
+Mnemonic::
++
+`ecall`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 32, name: 0x73, attr: ["OP"]}
+]}
+....
+
+Description:: Generates an environment call exception, used to make a request to the execution environment (typically an operating system). This instruction is fundamental in implementing system calls, which are the primary mechanism for user-level programs to request services from the operating system. When an ECALL is executed, control is transferred to the operating system or execution environment, which then determines the nature of the request based on values in specific registers. ECALL is crucial in implementing features like file I/O, process management, and other operating system services. In bare-metal environments, it can be used to implement custom exception handling or to switch between different modes of operation.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute ECALL() = {
+  let t : sync_exception =
+    struct { trap = match (cur_privilege) {
+                      User       => E_U_EnvCall(),
+                      Supervisor => E_S_EnvCall(),
+                      Machine    => E_M_EnvCall()
+                    },
+             excinfo = (None() : option(xlenbits)),
+             ext     = None() };
+  set_next_pc(exception_handler(cur_privilege, CTL_TRAP(t), PC));
+  RETIRE_FAIL
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-fence]]
+==== FENCE
+
+Synopsis:: Enforce ordering between memory operations
+
+Mnemonic::
++
+`fence fm, pred, succ, rs1, rd`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0xf, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 4, name: 'succ'},
+{bits: 4, name: 'pred'},
+{bits: 4, name: 'fm'}
+]}
+....
+
+Description:: Ensures that all memory accesses and I/O operations issued before the FENCE instruction are completed before any memory accesses or I/O operations after the FENCE are issued. This instruction is crucial in multicore and multiprocessor systems for enforcing memory ordering. FENCE is used to create synchronization points in code, ensuring that all memory operations are visible to other cores or devices in a specific order. It's particularly important in implementing lock-free algorithms, in managing shared memory between cores, and in ensuring proper ordering of memory accesses with respect to memory-mapped I/O operations. FENCE can have different variants to specify which types of operations (reads, writes, I/O) need to be ordered.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|fm |input |Fence mask
+|pred |input |Predecessor fence ordering
+|succ |input |Successor fence ordering
+|rs1 |input |Source register 1
+|rd |output |Destination register
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (FENCE(pred, succ)) = {
+  // If the FIOM bit in menvcfg/senvcfg is set then the I/O bits can imply R/W.
+  let fiom = is_fiom_active();
+  let pred = effective_fence_set(pred, fiom);
+  let succ = effective_fence_set(succ, fiom);
+
+  match (pred, succ) {
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b11) => sail_barrier(Barrier_RISCV_rw_rw),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b11) => sail_barrier(Barrier_RISCV_r_rw),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b10) => sail_barrier(Barrier_RISCV_r_r),
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b01) => sail_barrier(Barrier_RISCV_rw_w),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b01) => sail_barrier(Barrier_RISCV_w_w),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b11) => sail_barrier(Barrier_RISCV_w_rw),
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b10) => sail_barrier(Barrier_RISCV_rw_r),
+    (_ : bits(2) @ 0b10, _ : bits(2) @ 0b01) => sail_barrier(Barrier_RISCV_r_w),
+    (_ : bits(2) @ 0b01, _ : bits(2) @ 0b10) => sail_barrier(Barrier_RISCV_w_r),
+
+    (_ : bits(4)       , _ : bits(2) @ 0b00) => (),
+    (_ : bits(2) @ 0b00, _ : bits(4)       ) => (),
+
+    _ => { print("FIXME: unsupported fence");
+           () }
+  };
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-fence_tso]]
+==== FENCE_TSO
+
+Synopsis:: Total Store Ordering fence
+
+Mnemonic::
++
+`fence_tso rs1, rd`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0xf, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 0x833, attr:["funct3"]}
+]}
+....
+
+Description:: Provides Total Store Ordering (TSO) memory consistency. It ensures that all stores before the FENCE.TSO instruction are globally visible before any loads after the instruction are performed. This instruction is a lighter-weight version of the general FENCE instruction, specifically designed for architectures that support TSO memory models. FENCE.TSO is particularly useful in implementing synchronization primitives and in porting code from architectures with stronger memory models (like x86) to RISC-V. It provides a balance between the strict ordering of FENCE and the relaxed ordering of normal memory operations, allowing for potential performance optimizations while still ensuring necessary memory consistency in concurrent programs.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rs1 |input |Source register 1
+|rd |output |Destination register
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (FENCE_TSO(pred, succ)) = {
+  match (pred, succ) {
+    (_ : bits(2) @ 0b11, _ : bits(2) @ 0b11) => sail_barrier(Barrier_RISCV_tso),
+    (_ : bits(2) @ 0b00, _ : bits(2) @ 0b00) => (),
+
+    _ => { print("FIXME: unsupported fence");
+           () }
+  };
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-jal]]
+==== JAL
+
+Synopsis:: Jump and Link to target address, storing return address
+
+Mnemonic::
++
+`jal rd, imm[20|10:1|11|19:12]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x6f, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 8, name: 'imm[19:12]'},
+{bits: 1, name: '[11]'},
+{bits: 10, name: 'imm[10:1]'},
+{bits: 1, name: '[20]'}
+]}
+....
+
+Description:: Performs an unconditional jump to a PC-relative offset and saves the address of the next instruction (PC+4) in the destination register (usually x1/ra). The offset is encoded in the immediate field, allowing jumps of up to ±1 MiB. This instruction is primarily used for procedure calls, where the return address needs to be saved. The large jump range makes it suitable for most function calls within a program. If the rd field is zero, no return address is saved, allowing JAL to be used for unconditional branches as well.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|jimm20 |input |20-bit jump offset
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_JAL(imm, rd)) = {
+  let t : xlenbits = PC + sign_extend(imm);
+  /* Extensions get the first checks on the target address. */
+  match ext_control_check_pc(t) {
+    Ext_ControlAddr_Error(e) => {
+      ext_handle_control_check_error(e);
+      RETIRE_FAIL
+    },
+    Ext_ControlAddr_OK(target) => {
+      /* Perform standard alignment check */
+      if bit_to_bool(target[1]) & not(extensionEnabled(Ext_C))
+      then {
+        handle_mem_exception(target, E_Fetch_Addr_Align());
+        RETIRE_FAIL
+      } else {
+        X(rd) = get_next_pc();
+        set_next_pc(target);
+        RETIRE_SUCCESS
+      }
+    }
+  }
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-jalr]]
+==== JALR
+
+Synopsis:: Jump and Link to computed target, storing return address
+
+Mnemonic::
++
+`jalr rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x67, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Jumps to an address computed from a base register (rs1) and a 12-bit immediate offset, saving the address of the next instruction (PC+4) in the destination register (usually x1/ra). This instruction is more flexible than JAL as it allows for computed jumps and can be used for returns, indirect calls, and implementing switch statements. The computed target address is the sum of rs1 and the sign-extended 12-bit immediate, with the least significant bit set to zero. This instruction is crucial for implementing function returns and for calling functions through function pointers.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+
+Sail Code::
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-lb]]
+==== LB
+
+Synopsis:: Load signed Byte from memory
+
+Mnemonic::
++
+`lb rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x3, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Loads an 8-bit value from memory, sign-extends it to XLEN bits (32 bits in RV32, 64 bits in RV64), and writes it to rd. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This instruction is crucial for accessing individual bytes in memory, such as when working with character data or packed data structures. The sign-extension allows for proper handling of signed 8-bit values in larger integer contexts. LB is often used in string processing, parsing binary data, and accessing byte-addressable devices.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute(LB(imm, rs1, rd, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+  match translateAddr(vaddr, Read(Data)) {
+    TR_Failure(e, _) => { handle_mem_exception(vaddr, e); 
+                        RETIRE_FAIL },
+    TR_Address(paddr, _) => 
+      match mem_read(Read(Data), paddr, 1, aq, rl, false) {
+        MemValue(result) => { X(rd) = sign_extend(result[7..0]); 
+                            RETIRE_SUCCESS },
+        MemException(e) => { handle_mem_exception(vaddr, e); 
+                           RETIRE_FAIL },
+      }
+  }
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-lbu]]
+==== LBU
+
+Synopsis:: Load unsigned Byte from memory
+
+Mnemonic::
++
+`lbu rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x3, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x4, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Loads an 8-bit value from memory, zero-extends it to XLEN bits, and writes it to rd. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This instruction is used for loading unsigned byte values, ensuring that the upper bits are always zero. It's particularly useful when working with unsigned char types in C, or when processing binary data where the high bits should not be interpreted as a sign. LBU is often used in network protocol implementations, file I/O operations, and when working with binary file formats.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute(LBU(imm, rs1, rd, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+  match translateAddr(vaddr, Read(Data)) {
+     TR_Failure(e, _) => { handle_mem_exception(vaddr, e); 
+                         RETIRE_FAIL },
+     TR_Address(paddr, _) => 
+       match mem_read(Read(Data), paddr, 1, aq, rl, false) {
+         MemValue(result) => { X(rd) = zero_extend(result[7..0]); 
+                             RETIRE_SUCCESS },
+         MemException(e) => { handle_mem_exception(vaddr, e); 
+                            RETIRE_FAIL },
+       }
+  }
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-lh]]
+==== LH
+
+Synopsis:: Load signed Halfword from memory
+
+Mnemonic::
++
+`lh rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x3, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x1, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Loads a 16-bit value from memory, sign-extends it to XLEN bits, and writes it to rd. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This instruction is used for accessing 16-bit (halfword) data types, such as short integers in C. The sign-extension ensures that signed 16-bit values are correctly interpreted in 32-bit or 64-bit contexts. LH is commonly used in audio processing (for 16-bit samples), in graphics (for certain color depths), and in working with communication protocols that use 16-bit data units.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute(LH(imm, rs1, rd, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+  if vaddr[0] != 0b0 then {
+    handle_mem_exception(vaddr, E_Load_Addr_Align());
+    RETIRE_FAIL
+  } else match translateAddr(vaddr, Read(Data)) {
+    TR_Failure(e, _) => { handle_mem_exception(vaddr, e); 
+                        RETIRE_FAIL },
+    TR_Address(paddr, _) => 
+      match mem_read(Read(Data), paddr, 2, aq, rl, false) {
+        MemValue(result) => { X(rd) = sign_extend(result[15..0]); 
+                            RETIRE_SUCCESS },
+        MemException(e) => { handle_mem_exception(vaddr, e); 
+                           RETIRE_FAIL },
+      }
+  }
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-lhu]]
+==== LHU
+
+Synopsis:: Load unsigned Halfword from memory
+
+Mnemonic::
++
+`lhu rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x3, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x5, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Loads a 16-bit value from memory, zero-extends it to XLEN bits, and writes it to rd. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This instruction is used for loading unsigned halfword (16-bit) values, ensuring that the upper bits are always zero. It's commonly used when working with unsigned short types in C, or in graphics and audio processing where 16-bit unsigned values are common (e.g., certain color or sample formats). LHU is also useful in network protocols and file formats that use 16-bit unsigned fields.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code::
+[source,sail]
+--
+function clause execute(LHU(imm, rs1, rd, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+  if vaddr[0] != 0b0 then {
+    handle_mem_exception(vaddr, E_Load_Addr_Align());
+    RETIRE_FAIL
+  } else match translateAddr(vaddr, Read(Data)) {
+     TR_Failure(e, _) => { handle_mem_exception(vaddr, e); 
+                         RETIRE_FAIL },
+     TR_Address(paddr, _) => 
+        match mem_read(Read(Data), paddr, 2, aq, rl, false) {
+           MemValue(result) => { X(rd) = zero_extend(result[15..0]); 
+                               RETIRE_SUCCESS },
+           MemException(e) => { handle_mem_exception(vaddr, e); 
+                              RETIRE_FAIL },
+        }
+  }
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-lui]]
+==== LUI
+
+Synopsis:: Load Upper Immediate
+
+Mnemonic::
++
+`lui rd, imm[31:12]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x37, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 20, name: 'imm[31:12]'}
+]}
+....
+
+Description:: Loads a 20-bit immediate value into the upper 20 bits of the destination register, setting the lower 12 bits to zero. This instruction is commonly used in conjunction with an ADDI instruction to create 32-bit constants. It's particularly useful for loading large constants or addresses into registers, as it allows for efficient encoding of 32-bit values using two instructions. The immediate value is sign-extended and shifted left by 12 bits before being placed in the destination register, which means it can represent multiples of 4096 (2^12).
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|imm20 |input |20-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute RISCV_LUI(imm, rd, op) = {
+  let off : xlenbits = sign_extend(imm @ 0x000);
+  let ret = off,
+  X(rd) = ret;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-lw]]
+==== LW
+
+Synopsis:: Load signed Word from memory
+
+Mnemonic::
++
+`lw rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x3, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x2, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Loads a 32-bit value from memory and writes it to rd. In RV64, the loaded value is sign-extended to 64 bits. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This is the primary instruction for loading 32-bit integers, single-precision floating-point values (when used by the F extension), and memory addresses in RV32. In RV64, it's still widely used for compatibility with 32-bit data and for accessing the lower half of 64-bit values. LW is fundamental in most memory operations, including array access, structure field access, and loading global variables.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute(LW(imm, rs1, rd, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+  if vaddr[1..0] != 0b00 then {
+    handle_mem_exception(vaddr, E_Load_Addr_Align());
+    RETIRE_FAIL
+  } else match translateAddr(vaddr, Read(Data)) {
+     TR_Failure(e, _) => { handle_mem_exception(vaddr, e); 
+                         RETIRE_FAIL },
+     TR_Address(paddr, _) => 
+        match mem_read(Read(Data), paddr, 4, aq, rl, false) {
+           MemValue(result) => { X(rd) = sign_extend(result[31..0]); 
+                               RETIRE_SUCCESS },
+           MemException(e) => { handle_mem_exception(vaddr, e); 
+                              RETIRE_FAIL },
+      }
+  }
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-or]]
+==== OR
+
+Synopsis:: OR two values
+
+Mnemonic::
++
+`or rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x6, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Performs bitwise OR between rs1 and rs2, writing the result to rd. This instruction is essential in bitwise operations and is widely used in various programming tasks. OR is primarily used for setting specific bits in a register while leaving others unchanged. It's commonly employed in flag manipulation, for example, in setting option bits in configuration words or status registers. In boolean algebra implementations, OR is used for logical OR operations. It's also useful in creating bitmasks, in certain bitfield manipulation techniques, and in implementing simple data merging operations. In graphics programming, OR can be used for combining multiple layers or applying certain effects.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_OR(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = rs1_val | rs2_val,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-ori]]
+==== ORI
+
+Synopsis:: OR Immediate
+
+Mnemonic::
++
+`ori rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x13, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x6, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Performs bitwise OR between rs1 and the sign-extended 12-bit immediate, writing the result to rd. ORI is essential for setting specific bits in a register while leaving others unchanged. It's often used in flag manipulation, for example, in setting option bits in configuration words. In boolean algebra implementations, ORI is used for logical OR operations with constants. It's also useful in creating bitmasks and in certain bitfield manipulation techniques.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_ORI (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result = rs1_val | immext,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sb]]
+==== SB
+
+Synopsis:: Store Byte to memory
+
+Mnemonic::
++
+`sb rs1, rs2, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x23, attr: ["OP"]},
+{bits: 5, name: 'imm[4:0]'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 'imm[11:5]'}
+]}
+....
+
+Description:: Stores the lowest 8 bits from rs2 to memory. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This instruction is essential for writing individual bytes to memory, which is crucial in many low-level operations. It's commonly used in string manipulation, when writing to byte-addressable devices, in network protocol implementations for setting individual flag bits, and in general when working with packed data structures or binary file formats.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|imm12hi |input |High 6 bits of 12-bit immediate
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|imm12lo |input |Low 6 bits of 12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute (SB(imm, rs2, rs1, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+
+  match translateAddr(vaddr, Write(Data)) {
+        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); 
+                               RETIRE_FAIL },
+        TR_Address(paddr, _) => {
+          let eares = mem_write_ea(paddr, 1, aq, rl, false);
+          match (eares) {
+            MemException(e) => { handle_mem_exception(vaddr, e); 
+                               RETIRE_FAIL },
+            MemValue(_) => {
+              let rs2_val = X(rs2);
+              match mem_write_value(paddr, 1, rs2_val[7 .. 0], aq, rl, false) {
+                MemValue(true)  => RETIRE_SUCCESS,
+                MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                MemException(e) => { handle_mem_exception(vaddr, e); 
+                                   RETIRE_FAIL }
+              }
+            }
+          }
+        }
+      }
+  }
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sh]]
+==== SH
+
+Synopsis:: Store Halfword to memory
+
+Mnemonic::
++
+`sh rs1, rs2, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x23, attr: ["OP"]},
+{bits: 5, name: 'imm[4:0]'},
+{bits: 3, name: 0x1, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 'imm[11:5]'}
+]}
+....
+
+Description:: Stores the lowest 16 bits from rs2 to memory. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This instruction is used for writing 16-bit (halfword) values to memory. It's commonly employed when working with short integer types, in audio processing for storing 16-bit samples, in graphics for certain color depth operations, and in various protocols and file formats that use 16-bit data units. SH is also useful in embedded systems where memory might be arranged in 16-bit words.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|imm12hi |input |High 6 bits of 12-bit immediate
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|imm12lo |input |Low 6 bits of 12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute (SH(imm, rs2, rs1, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+
+  match translateAddr(vaddr, Write(Data)) {
+        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); 
+                               RETIRE_FAIL },
+        TR_Address(paddr, _) => {
+          let eares = mem_write_ea(paddr, 2, aq, rl, false);
+          match (eares) {
+            MemException(e) => { handle_mem_exception(vaddr, e); 
+                               RETIRE_FAIL },
+            MemValue(_) => {
+              let rs2_val = X(rs2);
+              match mem_write_value(paddr, 2, rs2_val[15 .. 0], aq, rl, false) {
+                MemValue(true)  => RETIRE_SUCCESS,
+                MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                MemException(e) => { handle_mem_exception(vaddr, e); 
+                                   RETIRE_FAIL }
+              }
+            }
+          }
+        }
+      }
+  }
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sll]]
+==== SLL
+
+Synopsis:: Shift Left Logical
+
+Mnemonic::
++
+`sll rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x1, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Shifts rs1 left by the amount specified in the lower 5 (RV32) or 6 (RV64) bits of rs2, writing the result to rd. Left shifts are equivalent to multiplication by powers of 2, making SLL useful for efficient multiplication by constants. It's also crucial in various bit manipulation techniques, such as creating masks or extracting bitfields. In graphics and cryptography, SLL is often used for fast multiplication or for implementing certain algorithms. The instruction can also be used for aligning data to specific byte boundaries.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SLL(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = if   sizeof(xlen) == 32
+                  then rs1_val << (rs2_val[4..0])
+                  else rs1_val << (rs2_val[5..0]),
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-slt]]
+==== SLT
+
+Synopsis:: Set if Less Than (Signed)
+
+Mnemonic::
++
+`slt rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x2, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Compares rs1 and rs2 as signed integers. Sets rd to 1 if rs1 < rs2, 0 otherwise. This instruction is fundamental for implementing signed comparisons in more complex conditional structures. It's often used in sorting algorithms, in implementing min/max functions, and in various decision-making processes in programs. SLT can be used to create branching conditions for other instructions, allowing for more complex control flow. It's also useful in implementing certain mathematical functions that depend on the relative ordering of values.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SLT(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = zero_extend(bool_to_bits(rs1_val <_s rs2_val)),
+  let result = zero_extend(bool_to_bits(rs1_val <_u rs2_val)),
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-slti]]
+==== SLTI
+
+Synopsis:: Set if Less Than Immediate (Signed)
+
+Mnemonic::
++
+`slti rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x13, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x2, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Compares rs1 with the sign-extended immediate as signed integers. Sets rd to 1 if rs1 < imm, 0 otherwise. This instruction is used for signed comparisons with constants, which is useful in implementing conditional statements and loops in high-level languages. It's particularly efficient for range checks and for implementing min/max functions with compile-time known bounds. SLTI can be used to create bitmasks based on the sign of a value, which is useful in certain bit manipulation techniques.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SLTI (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result = zero_extend(bool_to_bits(rs1_val <_s immext)),
+  let result = zero_extend(bool_to_bits(rs1_val <_u immext)),
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sltiu]]
+==== SLTIU
+
+Synopsis:: Set if Less Than Immediate (Unsigned)
+
+Mnemonic::
++
+`sltiu rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x13, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x3, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Compares rs1 with the sign-extended immediate as unsigned integers. Sets rd to 1 if rs1 < imm, 0 otherwise. Despite the immediate being sign-extended, the comparison is unsigned. This instruction is crucial for unsigned comparisons with constants, often used in array bounds checking, pointer comparisons, and implementing unsigned arithmetic operations. It's also useful in creating bitmasks for unsigned values and in certain bitwise manipulation techniques. SLTIU with a zero immediate can be used to efficiently check if a register is zero.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SLTIU (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result = zero_extend(bool_to_bits(rs1_val <_u immext)),
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sltu]]
+==== SLTU
+
+Synopsis:: Set if Less Than (Unsigned)
+
+Mnemonic::
++
+`sltu rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x3, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Compares rs1 and rs2 as unsigned integers. Sets rd to 1 if rs1 < rs2, 0 otherwise. SLTU is essential for unsigned comparisons, often used with memory addresses, array indices, and other naturally unsigned values. It's particularly useful in bounds checking for arrays, in implementing unsigned arithmetic operations, and in certain low-level memory management tasks. SLTU can be more efficient than SLT for certain types of comparisons, especially when dealing with memory addresses or when the values are known to be non-negative.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SLTU(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = zero_extend(bool_to_bits(rs1_val <_u rs2_val)),
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sra]]
+==== SRA
+
+Synopsis:: Shift Right Arithmetic
+
+Mnemonic::
++
+`sra rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x5, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x20, attr:["funct7"]}
+]}
+....
+
+Description:: Shifts rs1 right by the amount specified in the lower 5 (RV32) or 6 (RV64) bits of rs2, sign-extending (copying the most significant bit). Writes the result to rd. Arithmetic right shifts are equivalent to division by powers of 2 for signed integers, rounding towards negative infinity. SRA is essential in implementing efficient signed division by constants and in certain signal processing operations. It's also used in various algorithms where the
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SRA(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = if   sizeof(xlen) == 32
+                  then shift_right_arith32(rs1_val, rs2_val[4..0])
+                  else shift_right_arith64(rs1_val, rs2_val[5..0])
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-srl]]
+==== SRL
+
+Synopsis:: Shift Right Logical
+
+Mnemonic::
++
+`srl rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x5, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Shifts rs1 right by the amount specified in the lower 5 (RV32) or 6 (RV64) bits of rs2, filling with zeros. Writes the result to rd. Right logical shifts are equivalent to division by powers of 2 for unsigned integers, making SRL useful for efficient division by constants. It's crucial in various bit manipulation techniques, such as extracting the least significant bits of a value. SRL is often used in implementing unsigned integer division algorithms, in certain cryptographic operations, and in graphics processing for color manipulation.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SRL(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = if   sizeof(xlen) == 32
+                  then rs1_val >> (rs2_val[4..0])
+                  else rs1_val >> (rs2_val[5..0]),
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sub]]
+==== SUB
+
+Synopsis:: Subtract one value from another
+
+Mnemonic::
++
+`sub rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x0, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x20, attr:["funct7"]}
+]}
+....
+
+Description:: Subtracts rs2 from rs1, writing the result to rd. Subtraction is essential in many computational tasks, including address offset calculations, implementing decremental loops, and general arithmetic operations. SUB is often used in comparison operations (by subtracting and then checking the sign of the result) and in implementing more complex mathematical functions. In pointer arithmetic, it's used to calculate the distance between two pointers. SUB is also key in implementing two's complement negation (by subtracting from zero).
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_SUB(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = rs1_val - rs2_val,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-sw]]
+==== SW
+
+Synopsis:: Store Word to memory
+
+Mnemonic::
++
+`sw rs1, rs2, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x23, attr: ["OP"]},
+{bits: 5, name: 'imm[4:0]'},
+{bits: 3, name: 0x2, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 'imm[11:5]'}
+]}
+....
+
+Description:: Stores the lowest 32 bits from rs2 to memory. The effective address is obtained by adding register rs1 to the sign-extended 12-bit offset. This is the primary instruction for storing 32-bit values to memory, including integers, single-precision floating-point values (when used by the F extension), and memory addresses in RV32. In RV64, it's used for storing the lower half of 64-bit values and for compatibility with 32-bit data. SW is fundamental in most memory write operations, including array updates, structure field modifications, and storing computed results or updated global variables.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|imm12hi |input |High 6 bits of 12-bit immediate
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|imm12lo |input |Low 6 bits of 12-bit immediate
+|===
+
+Sail Code:: 
+[source,sail]
+--
+function clause execute (SW(imm, rs2, rs1, aq, rl)) = {
+  let offset : xlenbits = sign_extend(imm);
+  let vaddr = X(rs1) + offset;
+
+  match translateAddr(vaddr, Write(Data)) {
+        TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); 
+                               RETIRE_FAIL },
+        TR_Address(paddr, _) => {
+          let eares = mem_write_ea(paddr, 4, aq, rl, false);
+          match (eares) {
+            MemException(e) => { handle_mem_exception(vaddr, e); 
+                               RETIRE_FAIL },
+            MemValue(_) => {
+              let rs2_val = X(rs2);
+              match mem_write_value(paddr, 4, rs2_val[31 .. 0], aq, rl, false) {
+                MemValue(true)  => RETIRE_SUCCESS,
+                MemValue(false) => internal_error(__FILE__, __LINE__, "store got false from mem_write_value"),
+                MemException(e) => { handle_mem_exception(vaddr, e); 
+                                   RETIRE_FAIL }
+              }
+            }
+          }
+        }
+      }
+  }
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-xor]]
+==== XOR
+
+Synopsis:: Exclusive OR two values
+
+Mnemonic::
++
+`xor rd, rs1, rs2`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x33, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x4, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 5, name: 'rs2'},
+{bits: 7, name: 0x0, attr:["funct7"]}
+]}
+....
+
+Description:: Performs bitwise XOR between rs1 and rs2, writing the result to rd. XOR is a versatile operation used in various contexts. In cryptography, it's fundamental to many encryption algorithms and in generating pseudo-random sequences. XOR is used for simple checksums and hash functions, and for toggling bits based on a mask. It's also useful in certain arithmetic operations, like swapping values without a temporary variable or detecting changes between two values. In graphics, XOR can be used for simple drawing operations that can be easily undone.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|rs2 |input |Source register 2
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_XOR(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result = rs1_val ^ rs2_val,
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<
+
+[[instruction-xori]]
+==== XORI
+
+Synopsis:: Exclusive OR Immediate
+
+Mnemonic::
++
+`xori rd, rs1, imm[11:0]`
++
+
+Encoding::
+[wavedrom, , svg]
+....
+{reg: [
+{bits: 7, name: 0x13, attr: ["OP"]},
+{bits: 5, name: 'rd'},
+{bits: 3, name: 0x4, attr:["funct3"]},
+{bits: 5, name: 'rs1'},
+{bits: 12, name: 'imm[11:0]'}
+]}
+....
+
+Description:: Performs bitwise XOR between rs1 and the sign-extended 12-bit immediate, writing the result to rd. This instruction is versatile in bitwise operations. It's commonly used for toggling specific bits, implementing simple hash functions, and in certain encryption algorithms. XORI with an immediate of -1 (all ones) performs a bitwise NOT operation, which is useful for inverting bits or implementing logical negation. In boolean algebra implementations, XORI is crucial for exclusive-or operations.
+
+Arguments::
+[%autowidth]
+[%header,cols="4,2,2"]
+|===
+|Register |Direction |Definition
+|rd |output |Destination register
+|rs1 |input |Source register 1
+|imm12 |input |12-bit immediate
+|===
+
+Sail Code:: 
+
+[source,sail]
+--
+function clause execute (RISCV_XORI (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result = rs1_val ^ immext
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+--
+
+Included in:: <<rv32,RV32>>, RV64I
+
+<<<

--- a/src/instrs/instr-encoding-rv_i.adoc
+++ b/src/instrs/instr-encoding-rv_i.adoc
@@ -6,9 +6,8 @@
 Synopsis:: Add two values
 
 Mnemonic::
-+
-`add rd, rs1, rs2`
-+
+add rd, rs1, rs2
+
 
 Encoding::
 [wavedrom, , svg]
@@ -35,7 +34,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -48,7 +47,7 @@ function clause execute (RISCV_ADD(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -58,9 +57,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Add Immediate
 
 Mnemonic::
-+
-`addi rd, rs1, imm[11:0]`
-+
+addi rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -86,7 +83,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -99,7 +96,7 @@ function clause execute (RISCV_ADDI (imm, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -109,9 +106,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: AND two values
 
 Mnemonic::
-+
-`and rd, rs1, rs2`
-+
+and rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -138,7 +133,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -151,7 +146,7 @@ function clause execute (RISCV_AND(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -161,9 +156,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: AND Immediate
 
 Mnemonic::
-+
-`andi rd, rs1, imm[11:0]`
-+
+andi rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -189,7 +182,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -202,7 +195,7 @@ function clause execute (RISCV_ANDI (imm, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -212,9 +205,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Add Upper Immediate to PC
 
 Mnemonic::
-+
-`auipc rd, imm[31:12]`
-+
+auipc rd, imm[31:12]
 
 Encoding::
 [wavedrom, , svg]
@@ -237,7 +228,7 @@ Arguments::
 |imm20 |input |20-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -249,7 +240,7 @@ function clause execute RISCV_AUIPC(imm, rd, op) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -259,9 +250,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Branch if Equal
 
 Mnemonic::
-+
-`beq rs1, rs2, imm[12:1]`
-+
+beq rs1, rs2, imm[12:1]
 
 Encoding::
 [wavedrom, , svg]
@@ -291,7 +280,7 @@ Arguments::
 |bimm12lo |input |Low bits of 12-bit branch offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -321,7 +310,7 @@ function clause execute (RISCV_BEQ(imm, rs2, rs1)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -331,9 +320,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Branch if Greater than or Equal (Signed)
 
 Mnemonic::
-+
-`bge rs1, rs2, imm[12:1]`
-+
+bge rs1, rs2, imm[12:1]
 
 Encoding::
 [wavedrom, , svg]
@@ -363,7 +350,7 @@ Arguments::
 |bimm12lo |input |Low bits of 12-bit branch offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -393,7 +380,7 @@ function clause execute (RISCV_BGE(imm, rs2, rs1)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -403,9 +390,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Branch if Greater than or Equal (Unsigned)
 
 Mnemonic::
-+
-`bgeu rs1, rs2, imm[12:1]`
-+
+bgeu rs1, rs2, imm[12:1]
 
 Encoding::
 [wavedrom, , svg]
@@ -435,7 +420,7 @@ Arguments::
 |bimm12lo |input |Low bits of 12-bit branch offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -465,7 +450,7 @@ function clause execute (RISCV_BGEU(imm, rs2, rs1)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -475,9 +460,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Branch if Less Than (Signed)
 
 Mnemonic::
-+
-`blt rs1, rs2, imm[12:1]`
-+
+blt rs1, rs2, imm[12:1]
 
 Encoding::
 [wavedrom, , svg]
@@ -507,7 +490,7 @@ Arguments::
 |bimm12lo |input |Low bits of 12-bit branch offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -537,7 +520,7 @@ function clause execute (RISCV_BLT(imm, rs2, rs1)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -547,9 +530,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Branch if Less Than (Unsigned)
 
 Mnemonic::
-+
-`bltu rs1, rs2, imm[12:1]`
-+
+bltu rs1, rs2, imm[12:1]
 
 Encoding::
 [wavedrom, , svg]
@@ -579,7 +560,7 @@ Arguments::
 |bimm12lo |input |Low bits of 12-bit branch offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -609,7 +590,7 @@ function clause execute (RISCV_BLTU(imm, rs2, rs1)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -619,9 +600,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Branch if Not Equal
 
 Mnemonic::
-+
-`bne rs1, rs2, imm[12:1]`
-+
+bne rs1, rs2, imm[12:1]
 
 Encoding::
 [wavedrom, , svg]
@@ -651,7 +630,7 @@ Arguments::
 |bimm12lo |input |Low bits of 12-bit branch offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -681,7 +660,7 @@ function clause execute (RISCV_BNE(imm, rs2, rs1)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -691,9 +670,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Environment break
 
 Mnemonic::
-+
-`ebreak`
-+
+ebreak
 
 Encoding::
 [wavedrom, , svg]
@@ -712,7 +689,7 @@ Arguments::
 |Register |Direction |Definition
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -722,7 +699,7 @@ function clause execute EBREAK() = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -732,9 +709,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Environment call
 
 Mnemonic::
-+
-`ecall`
-+
+ecall
 
 Encoding::
 [wavedrom, , svg]
@@ -753,7 +728,7 @@ Arguments::
 |Register |Direction |Definition
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -771,7 +746,7 @@ function clause execute ECALL() = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -781,9 +756,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Enforce ordering between memory operations
 
 Mnemonic::
-+
-`fence fm, pred, succ, rs1, rd`
-+
+fence fm, pred, succ, rs1, rd
 
 Encoding::
 [wavedrom, , svg]
@@ -813,7 +786,7 @@ Arguments::
 |rd |output |Destination register
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -844,7 +817,7 @@ function clause execute (FENCE(pred, succ)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -854,9 +827,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Total Store Ordering fence
 
 Mnemonic::
-+
-`fence_tso rs1, rd`
-+
+fence_tso rs1, rd
 
 Encoding::
 [wavedrom, , svg]
@@ -881,7 +852,7 @@ Arguments::
 |rd |output |Destination register
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -897,7 +868,7 @@ function clause execute (FENCE_TSO(pred, succ)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -907,9 +878,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Jump and Link to target address, storing return address
 
 Mnemonic::
-+
-`jal rd, imm[20|10:1|11|19:12]`
-+
+jal rd, imm[20|10:1|11|19:12]
 
 Encoding::
 [wavedrom, , svg]
@@ -935,7 +904,7 @@ Arguments::
 |jimm20 |input |20-bit jump offset
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -963,7 +932,8 @@ function clause execute (RISCV_JAL(imm, rd)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -973,9 +943,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Jump and Link to computed target, storing return address
 
 Mnemonic::
-+
-`jalr rd, rs1, imm[11:0]`
-+
+jalr rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1002,8 +970,9 @@ Arguments::
 |===
 
 
-Sail Code::
-Included in:: <<rv32,RV32>>, RV64I
+Operation::
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1013,9 +982,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Load signed Byte from memory
 
 Mnemonic::
-+
-`lb rd, rs1, imm[11:0]`
-+
+lb rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1041,7 +1008,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute(LB(imm, rs1, rd, aq, rl)) = {
@@ -1061,7 +1028,7 @@ function clause execute(LB(imm, rs1, rd, aq, rl)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
 
 <<<
 
@@ -1071,9 +1038,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Load unsigned Byte from memory
 
 Mnemonic::
-+
-`lbu rd, rs1, imm[11:0]`
-+
+lbu rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1099,7 +1064,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute(LBU(imm, rs1, rd, aq, rl)) = {
@@ -1119,7 +1084,8 @@ function clause execute(LBU(imm, rs1, rd, aq, rl)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1129,9 +1095,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Load signed Halfword from memory
 
 Mnemonic::
-+
-`lh rd, rs1, imm[11:0]`
-+
+lh rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1157,7 +1121,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute(LH(imm, rs1, rd, aq, rl)) = {
@@ -1180,7 +1144,8 @@ function clause execute(LH(imm, rs1, rd, aq, rl)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1190,9 +1155,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Load unsigned Halfword from memory
 
 Mnemonic::
-+
-`lhu rd, rs1, imm[11:0]`
-+
+lhu rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1218,7 +1181,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code::
+Operation::
 [source,sail]
 --
 function clause execute(LHU(imm, rs1, rd, aq, rl)) = {
@@ -1241,7 +1204,8 @@ function clause execute(LHU(imm, rs1, rd, aq, rl)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1251,9 +1215,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Load Upper Immediate
 
 Mnemonic::
-+
-`lui rd, imm[31:12]`
-+
+lui rd, imm[31:12]
 
 Encoding::
 [wavedrom, , svg]
@@ -1276,7 +1238,7 @@ Arguments::
 |imm20 |input |20-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1288,7 +1250,8 @@ function clause execute RISCV_LUI(imm, rd, op) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1298,9 +1261,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Load signed Word from memory
 
 Mnemonic::
-+
-`lw rd, rs1, imm[11:0]`
-+
+lw rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1326,7 +1287,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute(LW(imm, rs1, rd, aq, rl)) = {
@@ -1349,7 +1310,8 @@ function clause execute(LW(imm, rs1, rd, aq, rl)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1359,9 +1321,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: OR two values
 
 Mnemonic::
-+
-`or rd, rs1, rs2`
-+
+or rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -1388,7 +1348,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1401,7 +1361,8 @@ function clause execute (RISCV_OR(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1411,9 +1372,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: OR Immediate
 
 Mnemonic::
-+
-`ori rd, rs1, imm[11:0]`
-+
+ori rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1439,7 +1398,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1452,7 +1411,8 @@ function clause execute (RISCV_ORI (imm, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1462,9 +1422,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Store Byte to memory
 
 Mnemonic::
-+
-`sb rs1, rs2, imm[11:0]`
-+
+sb rs1, rs2, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1492,7 +1450,7 @@ Arguments::
 |imm12lo |input |Low 6 bits of 12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute (SB(imm, rs2, rs1, aq, rl)) = {
@@ -1522,7 +1480,8 @@ function clause execute (SB(imm, rs2, rs1, aq, rl)) = {
   }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1532,9 +1491,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Store Halfword to memory
 
 Mnemonic::
-+
-`sh rs1, rs2, imm[11:0]`
-+
+sh rs1, rs2, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1562,7 +1519,7 @@ Arguments::
 |imm12lo |input |Low 6 bits of 12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute (SH(imm, rs2, rs1, aq, rl)) = {
@@ -1592,7 +1549,8 @@ function clause execute (SH(imm, rs2, rs1, aq, rl)) = {
   }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1602,9 +1560,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Shift Left Logical
 
 Mnemonic::
-+
-`sll rd, rs1, rs2`
-+
+sll rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -1631,7 +1587,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1646,7 +1602,8 @@ function clause execute (RISCV_SLL(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1656,9 +1613,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Set if Less Than (Signed)
 
 Mnemonic::
-+
-`slt rd, rs1, rs2`
-+
+slt rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -1685,7 +1640,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1699,7 +1654,8 @@ function clause execute (RISCV_SLT(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1709,9 +1665,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Set if Less Than Immediate (Signed)
 
 Mnemonic::
-+
-`slti rd, rs1, imm[11:0]`
-+
+slti rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1737,7 +1691,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1751,7 +1705,8 @@ function clause execute (RISCV_SLTI (imm, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1761,9 +1716,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Set if Less Than Immediate (Unsigned)
 
 Mnemonic::
-+
-`sltiu rd, rs1, imm[11:0]`
-+
+sltiu rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -1789,7 +1742,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1802,7 +1755,8 @@ function clause execute (RISCV_SLTIU (imm, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1812,9 +1766,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Set if Less Than (Unsigned)
 
 Mnemonic::
-+
-`sltu rd, rs1, rs2`
-+
+sltu rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -1841,7 +1793,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1854,7 +1806,8 @@ function clause execute (RISCV_SLTU(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1864,9 +1817,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Shift Right Arithmetic
 
 Mnemonic::
-+
-`sra rd, rs1, rs2`
-+
+sra rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -1893,7 +1844,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1908,7 +1859,8 @@ function clause execute (RISCV_SRA(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1918,9 +1870,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Shift Right Logical
 
 Mnemonic::
-+
-`srl rd, rs1, rs2`
-+
+srl rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -1947,7 +1897,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -1962,7 +1912,8 @@ function clause execute (RISCV_SRL(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -1972,9 +1923,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Subtract one value from another
 
 Mnemonic::
-+
-`sub rd, rs1, rs2`
-+
+sub rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -2001,7 +1950,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -2014,7 +1963,8 @@ function clause execute (RISCV_SUB(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -2024,9 +1974,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Store Word to memory
 
 Mnemonic::
-+
-`sw rs1, rs2, imm[11:0]`
-+
+sw rs1, rs2, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -2054,7 +2002,7 @@ Arguments::
 |imm12lo |input |Low 6 bits of 12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 [source,sail]
 --
 function clause execute (SW(imm, rs2, rs1, aq, rl)) = {
@@ -2084,7 +2032,8 @@ function clause execute (SW(imm, rs2, rs1, aq, rl)) = {
   }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -2094,9 +2043,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Exclusive OR two values
 
 Mnemonic::
-+
-`xor rd, rs1, rs2`
-+
+xor rd, rs1, rs2
 
 Encoding::
 [wavedrom, , svg]
@@ -2123,7 +2070,7 @@ Arguments::
 |rs2 |input |Source register 2
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -2136,7 +2083,8 @@ function clause execute (RISCV_XOR(rs2, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<
 
@@ -2146,9 +2094,7 @@ Included in:: <<rv32,RV32>>, RV64I
 Synopsis:: Exclusive OR Immediate
 
 Mnemonic::
-+
-`xori rd, rs1, imm[11:0]`
-+
+xori rd, rs1, imm[11:0]
 
 Encoding::
 [wavedrom, , svg]
@@ -2174,7 +2120,7 @@ Arguments::
 |imm12 |input |12-bit immediate
 |===
 
-Sail Code:: 
+Operation:: 
 
 [source,sail]
 --
@@ -2187,6 +2133,7 @@ function clause execute (RISCV_XORI (imm, rs1, rd, op)) = {
 }
 --
 
-Included in:: <<rv32,RV32>>, RV64I
+Included in:: <<rv32,RV32I>>, <<rv64,RV64I>> 
+
 
 <<<

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -1072,3 +1072,5 @@ hints, security tags, and instrumentation flags for simulation/emulation.
 
 TIP: When allocating `slli x0, x0, 0x1f` or `srai x0, x0, 7` as custom HINTs,
 take note of their use in semihosting calls, as described in <<ecall-ebreak>>.
+
+include::instrs/instr-encoding-rv_i.adoc[]


### PR DESCRIPTION
Hello!

This PR introduces a continuation of the approach to instruction-per-page documentation for RISC-V that has been followed by newer extensions like  "B", Vector crypto and Scalar crypto. We are actively trying to improve the process of documentation generation and believe that aligning the base ISA with these extensions would greatly increase the manual.  We recognize that there might be things to improve and that we are fully open to address any feedback.

Key points:
* Enhanced instruction description structure:
  * Synopsis
  * Mnemonic
  * Encoding - with attributes
  * Description
  * Arguments
  * Operation (SAIL Code - retrieved from the SAIL repository)
  * Included in - (Extensions)
* Automated documentation generation:
As discussed in #1590 we are also trying to achieve a nice automation process based on existing repos and minimizing our impact as we possible can. Please take note that, in order to achieve the most of this layout, we refined some of the SAIL Code by hand.

Current status:
* Proof of concept covering a subset of RISC-V instructions (RV32I)
* Example output available in the RISC-V instructions PDF [riscv-unprivileged.pdf](https://github.com/user-attachments/files/16637589/riscv-unprivileged.pdf)

There is a possibility here to impact the 200+ instructions in the manual that aren't still in this format if this approach is welcomed.

We welcome feedback on the approach, output quality, and potential modifications to existing repositories to support this effort.

Related issues: #1470, #1369, #1253, #1396, #1567